### PR TITLE
fix: controller should list all virtualservicemerges, not just those in the same namespace

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -72,7 +72,7 @@ func (r *VirtualServicePatchReconciler) Configure(ctx reconciler.Context) error 
 			// get all virtual service merge whose target is this virtual service
 			vsmegeList := &v1alpha1.VirtualServiceMergeList{}
 			if err := r.Client().List(context.TODO(), vsmegeList, &client.ListOptions{
-				Namespace: vs.GetNamespace(),
+				// Namespace: vs.GetNamespace(),
 			}); err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
### Current behavior

The istio-virtualservice-merger controller watches for changes to VirtualServices.

For each VirtualService that changed, the controller triggers reconciliation for VirtualServiceMerges (that target the changed VirtualService) that are in the same namespace as the changed VirtualService.

This fails to account for VirtualServiceMerges deployed to a different namespace than its target VirtualService.

Ex)
```yaml
# VirtualService
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: api-routes
  namespace: app-space
spec:
  gateways:
    - mesh
  hosts:
    - internal-api.monime.sl
---
# VirtualServiceMerge
apiVersion: istiomerger.monime.sl/v1alpha1
kind: VirtualServiceMerge
metadata:
  name: review-routes
  namespace: merge-space    # VSM namespace is different from VS namespace
spec:
  target:
    name: api-routes
    namespace: app-space
  patch:
    http:
      - match:
          - uri:
              prefix: /reviews
        route:
          - destination:
              host: review-service
              port:
                number: 8080
```

### Proposed behavior

For each changed VirtualService, the controller should trigger reconciliation for all VirtualServiceMerges (that target the changed VirtualService) regardless of the VirtualServiceMerge's namespace.

Again, this is because VirtualServiceMerges and their target VirtualServices can be deployed to different namespaces.

### Tests

We are currently using this edited version of the controller in production, and everything works as expected.