### PR TITLE
feat: controller should only watch for UpdateEvents for VirtualServices whose spec changes

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -93,7 +93,25 @@ func (r *VirtualServicePatchReconciler) Configure(ctx reconciler.Context) error 
 				}
 			}
 			return requests
-		})).
+		}),
+			builder.WithPredicates(
+				predicate.Funcs{
+					CreateFunc: func(e event.CreateEvent) bool {
+						return true
+					},
+					UpdateFunc: func(e event.UpdateEvent) bool {
+						// ignore updates in which case metadata.Generation does not change
+						return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+					},
+					DeleteFunc: func(e event.DeleteEvent) bool {
+						return false
+					},
+					GenericFunc: func(e event.GenericEvent) bool {
+						return false
+					},
+				},
+			),
+		).
 		Complete(r)
 }
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -100,7 +100,7 @@ func (r *VirtualServicePatchReconciler) Configure(ctx reconciler.Context) error 
 						return true
 					},
 					UpdateFunc: func(e event.UpdateEvent) bool {
-						// ignore updates in which case metadata.Generation does not change
+						// ignore updates where the VirtualService spec does not change
 						return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
 					},
 					DeleteFunc: func(e event.DeleteEvent) bool {


### PR DESCRIPTION
### Current behavior

The controller watches for all changes to VirtualServices, and triggers reconciliation for relevant VirtualServiceMerges.

### Proposed behavior

The controller doesn't necessarily need to watch for DeleteEvents, GenericEvents, and also UpdateEvents where the VirtualService spec has **not** changed.

The controller should limit itself to only watch for CreateEvents and UpdateEvents whose VirtualService spec has changed, in order not to trigger wasteful reconciliation cycles.

### Tests

We are currently using this edited version of the controller in production, and everything works as expected.